### PR TITLE
Update dev requirements so tests can run on new Python versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-black==19.10b0
-flake8==3.7.9
-isort==4.3.21
-twine==3.1.1
-wheel==0.33.6
-pytest==6.0.2
+black==22.6.0
+flake8==5.0.3
+isort==5.10.1
+twine==4.0.1
+wheel==0.37.1
+pytest==7.1.2


### PR DESCRIPTION
This patch updates the development dependencies to each tool's latest version.

pytest 6 doesn't run on Python 3.10 and crashes with a `TypeError`. Upgrading to the latest version allows the tests to run on newer Python releases.