### PR TITLE
git-ignore `.eggs/` and `.idea/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ html/
 build
 dist
 .venv
+.eggs/
+.idea/


### PR DESCRIPTION
* The `.eggs/` directory was created by setuptools when I installed the project dependencies.
* The `.idea/` directory was created by PyCharm when I began interacting with the codebase.

If this is merged it will help me focus on other changes to the codebase.