### PR TITLE
Use tox to manage testing of all supported Python versions and linters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ html/
 build
 dist
 .venv
+.eggs/
+.idea/
+.tox/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,11 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Quality Assurance",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 keywords = []
 urls = {Homepage = "https://github.com/thatch/regexlint/"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,7 @@ include-package-data = false
 
 
 [tool.isort]
-line-length = 88
-multi-line-output = 3
-force-grid-wrap = false
-include-trailing-comma = true
-use-parentheses = true
+profile = "black"
 
 [tool.flake8]
 ignore = "E203, E231, E266, E302, E501, W503, E741"

--- a/regexlint/indicator_pyg.py
+++ b/regexlint/indicator_pyg.py
@@ -17,8 +17,8 @@ This script is several layered hacks to be able to point out clang-style errors
 for a specific line of Python code (likely in a string literal).  Do not take
 as an example of well-written Python.
 """
-from ast import literal_eval
 import re
+from ast import literal_eval
 
 from pygments.lexers.agile import PythonLexer
 from pygments.token import Name, Punctuation, String

--- a/regexlint/util.py
+++ b/regexlint/util.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os import path
 from ast import literal_eval
+from os import path
 
 from pygments.token import Other
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
-black==19.10b0
-flake8==3.7.9
-isort==4.3.21
-twine==3.1.1
-wheel==0.33.6
-pytest==6.0.2
+black
+flake8
+isort
+pytest
+tox
+twine
+wheel

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import TestCase
 from ast import literal_eval
+from unittest import TestCase
 
 from regexlint.util import build_ranges, consistent_repr, eval_char
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+skip_missing_interpreters = true
+isolated_build = true
+envlist =
+    py{311, 310, 39, 38, 37}
+    black
+    isort
+
+[testenv]
+deps =
+    pygments
+    pytest
+
+commands =
+    pytest
+
+[testenv:black]
+skip_install = true
+deps = black
+commands = black --check .
+
+[testenv:isort]
+skip_install = true
+deps = isort
+commands = isort --check .


### PR DESCRIPTION
This patch introduces the following changes:

* tox is now a development dependency
* tox will test Python 3.7 through 3.11, and will run black and isort in `--check` mode
* Add various generated development and cache directories to `.gitignore`
* Add Python 3.9, 3.10, and 3.11 to the list of trove classifiers

If this is merged then I'll update CI to use tox as well so local development and CI are standardized. 👍 