### PR TITLE
Remove "null" checker

### DIFF
--- a/regexlint/checkers.py
+++ b/regexlint/checkers.py
@@ -38,15 +38,6 @@ from regexlint.util import (
 )
 
 
-def check_no_nulls(reg, errs):
-    num = "101"
-    level = logging.ERROR
-    msg = "Null characters not allowed (python docs)"
-    pos = reg.raw.find("\x00")
-    if pos != -1:
-        errs.append((num, level, pos, msg))
-
-
 def check_no_bels(reg, errs):
     num = "110"
     level = logging.ERROR

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -36,7 +36,6 @@ from regexlint.checkers import (
     check_no_consecutive_dots,
     check_no_empty_alternations,
     check_no_newlines,
-    check_no_nulls,
     check_prefix_ordering,
     check_redundant_repetition,
     check_single_character_classes,
@@ -49,12 +48,6 @@ from regexlint.parser import Regex, fmttree
 
 
 class CheckersTests(TestCase):
-    def test_null(self):
-        r = Regex.get_parse_tree("a\x00b")
-        errs = []
-        check_no_nulls(r, errs)
-        self.assertEqual(len(errs), 1)
-
     def test_newline(self):
         r = Regex.get_parse_tree("a\nb")
         errs = []


### PR DESCRIPTION
The Python documentation no longer states that regexes must not contain null characters starting with Python 3.6.