### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.10, 3.11, 3.12, 3.13, 3.14]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/regexlint/indicator_ast.py
+++ b/regexlint/indicator_ast.py
@@ -51,7 +51,11 @@ def find_offending_line(mod, clsname, state, idx, pos):
             continue
         stateValue = None
         for i, key in enumerate(item.keys):
-            if isinstance(key, ast.Str) and key.s == state:
+            if (
+                isinstance(key, ast.Constant)
+                and isinstance(key.value, str)
+                and key.value == state
+            ):
                 stateValue = item.values[i]
         if stateValue is None:
             continue
@@ -62,7 +66,10 @@ def find_offending_line(mod, clsname, state, idx, pos):
         idxTuple = stateValue.elts[idx]
         if not isinstance(idxTuple, ast.Tuple):
             continue
-        if len(idxTuple.elts) < 2 or not isinstance(idxTuple.elts[0], ast.Str):
+        if len(idxTuple.elts) < 2 or not (
+            isinstance(idxTuple.elts[0], ast.Constant)
+            and isinstance(idxTuple.elts[0].value, str)
+        ):
             continue
         lines = []
         startline = idxTuple.elts[0].lineno - 1

--- a/regexlint/parser.py
+++ b/regexlint/parser.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 import re
-import sre_parse
+
+try:
+    from re import _parser as sre_parse
+except ImportError:  # Python < 3.11
+    import sre_parse
 import sys
 import weakref
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,8 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sre_constants
-import sre_parse
+try:
+    from re import _constants as sre_constants
+    from re import _parser as sre_parse
+except ImportError:  # Python < 3.11
+    import sre_constants
+    import sre_parse
 from unittest import TestCase
 
 import pytest


### PR DESCRIPTION
Fix removed/deprecated stdlib APIs so the test suite passes on Python 3.14 without warnings:

- Replace ast.Str/.s (removed in 3.12) with ast.Constant/.value, guarding string constants with isinstance(..., str).
- Import sre_parse/sre_constants as re._parser/re._constants (available since 3.11), falling back to the legacy modules on older versions.