### PR TITLE
Add check for redundant lookarounds over assertions

### DIFF
--- a/regexlint/checkers.py
+++ b/regexlint/checkers.py
@@ -507,6 +507,40 @@ def check_redundant_repetition(reg, errs):
             errs.append((num, level, repeat.start, "should be +"))
 
 
+def check_redundant_lookaround(reg, errs):
+    # https://github.com/pygments/pygments/pull/3192
+    num = "126"
+    level = logging.WARNING
+
+    negative = (Other.Open.NegativeLookahead, Other.Open.NegativeLookbehind)
+    lookarounds = (Other.Open.Lookahead, Other.Open.Lookbehind) + negative
+    for node in find_all_by_type(reg, Other.Open):
+        if node.type not in lookarounds:
+            continue
+        body = node.children
+        # (?<=...) lexes its leading '=' as a literal child; drop it.
+        if node.type is Other.Open.Lookbehind:
+            body = body[1:]
+        if len(body) != 1 or body[0].type not in Other.Anchor:
+            continue
+        # A lookaround wrapping a single zero-width assertion is just the
+        # assertion (or its negation). Only \b has a named negation, \B.
+        if node.type in negative:
+            if body[0].type is Other.Anchor.WordBoundary:
+                errs.append(
+                    (num, level, node.start or 0, "Redundant lookaround, use \\B")
+                )
+        else:
+            errs.append(
+                (
+                    num,
+                    level,
+                    node.start or 0,
+                    "Redundant lookaround, use %s directly" % body[0].data,
+                )
+            )
+
+
 def manual_check_for_empty_string_match(reg, errs, raw_pat):
     # Skip the check in the following conditions:
     # * Rules that use a callback, since they're used for indentation

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -38,6 +38,7 @@ from regexlint.checkers import (
     check_no_newlines,
     check_no_nulls,
     check_prefix_ordering,
+    check_redundant_lookaround,
     check_redundant_repetition,
     check_single_character_classes,
     check_suspicious_anchors,
@@ -757,6 +758,80 @@ class CheckersTests(TestCase):
         check_redundant_repetition(r, errs)
         print(errs)
         self.assertEqual(len(errs), 1)
+
+    def test_redundant_lookaround(self):
+        for pat in (r"(?<=\b)", r"(?=\b)", r"(?!\b)", r"(?<!\b)", r"(?<=^)", r"(?=$)"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_lookaround(r, errs)
+            print(pat, errs)
+            self.assertEqual(len(errs), 1, pat)
+
+    def test_redundant_lookaround_string_anchors(self):
+        for pat in (r"(?=\A)", r"(?=\Z)", r"(?<=\A)", r"(?<=\Z)"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_lookaround(r, errs)
+            print(pat, errs)
+            self.assertEqual(len(errs), 1, pat)
+
+    def test_redundant_lookaround_embedded(self):
+        # The lookaround is only part of a larger pattern.
+        r = Regex.get_parse_tree(r"foo(?=\b)bar")
+        errs = []
+        check_redundant_lookaround(r, errs)
+        print(errs)
+        self.assertEqual(len(errs), 1)
+        # Reported at the position of the offending group.
+        self.assertEqual(errs[0][2], 3)
+
+    def test_redundant_lookaround_multiple(self):
+        r = Regex.get_parse_tree(r"(?=\b)x(?<=^)y(?!\b)")
+        errs = []
+        check_redundant_lookaround(r, errs)
+        print(errs)
+        self.assertEqual(len(errs), 3)
+
+    def test_redundant_lookaround_message(self):
+        r = Regex.get_parse_tree(r"(?=\b)")
+        errs = []
+        check_redundant_lookaround(r, errs)
+        self.assertEqual(len(errs), 1)
+        self.assertIn(r"\b", errs[0][3])
+        # Negative lookaround over \b suggests \B.
+        errs = []
+        check_redundant_lookaround(Regex.get_parse_tree(r"(?!\b)"), errs)
+        self.assertEqual(len(errs), 1)
+        self.assertIn(r"\B", errs[0][3])
+
+    def test_redundant_lookaround_ok(self):
+        # Lookarounds over more than a bare assertion, or negative lookarounds
+        # over anchors with no named negation.
+        for pat in (r"(?=\bx)", r"(?<=abc)", r"(?!foo)", r"(?<==)", r"(?!^)"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_lookaround(r, errs)
+            print(pat, errs)
+            self.assertEqual(len(errs), 0, pat)
+
+    def test_redundant_lookaround_ok_negative_anchors(self):
+        # Negative lookarounds over anchors other than \b have no named
+        # replacement, so they must not be flagged.
+        for pat in (r"(?!$)", r"(?<!^)", r"(?!\A)", r"(?<!\Z)"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_lookaround(r, errs)
+            print(pat, errs)
+            self.assertEqual(len(errs), 0, pat)
+
+    def test_redundant_lookaround_ok_plain_group(self):
+        # Ordinary (capturing / non-capturing) groups are never lookarounds.
+        for pat in (r"(\b)", r"(?:\b)", r"(^)", r"(?:$)"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_lookaround(r, errs)
+            print(pat, errs)
+            self.assertEqual(len(errs), 0, pat)
 
     def test_manual_empty_string(self):
         r = Regex.get_parse_tree("")


### PR DESCRIPTION
Flag zero-width lookarounds that wrap a single boundary/anchor assertion, since a lookaround over a zero-width assertion is just the assertion itself:

  (?=\b)/(?<=\b) -> \b, (?<=^) -> ^, (?=$) -> $, etc.
  (?!\b)/(?<!\b) -> \B  (\b is the only anchor with a named negation)

Negative lookarounds over other anchors have no simple replacement and are left alone, as are lookarounds wrapping more than a bare assertion.

This is the anti-pattern cleaned up in pygments/pygments#3192.

New checker 126 (check_redundant_lookaround), with tests.