### PR TITLE
Add ReDoS check for nested quantifiers

### DIFF
--- a/regexlint/checkers.py
+++ b/regexlint/checkers.py
@@ -592,6 +592,73 @@ def check_redundant_lookaround(reg, errs):
             )
 
 
+_UNBOUNDED_REPETITION = (
+    Other.Repetition.Star,
+    Other.Repetition.NongreedyStar,
+    Other.Repetition.Plus,
+    Other.Repetition.NongreedyPlus,
+)
+
+_CONSUMING_GROUP = (
+    Other.Open.Capturing,
+    Other.Open.NonCapturing,
+    Other.Open.NamedCapturing,
+)
+
+
+def _is_unbounded_repetition(node):
+    """True for *, +, and open-ended {n,} (the quantifiers that can match an
+    unbounded amount of text)."""
+    if node.type in _UNBOUNDED_REPETITION:
+        return True
+    return node.type is Other.Repetition.Curly and node.max is None
+
+
+def _body_is_ambiguously_repeatable(group):
+    """True when a group's whole body reduces to a single unbounded repetition
+    (possibly through nested single-child groups, or via an alternation branch).
+
+    That is the shape that makes ``(<group>)+`` catastrophic: the inner
+    quantifier can split the same input in exponentially many ways because no
+    fixed text delimits successive iterations. Bodies with a mandatory literal
+    part (e.g. ``ab+``) or single-character alternations (e.g. ``a|b``) are not
+    ambiguous and are intentionally left alone to avoid false positives.
+    """
+    children = group.children
+    # Unwrap chains of single-child groups, e.g. (?:(a+))+.
+    while len(children) == 1 and children[0].type in _CONSUMING_GROUP:
+        children = children[0].children
+    if len(children) != 1:
+        return False
+    child = children[0]
+    if _is_unbounded_repetition(child):
+        return True
+    if child.type is Other.Alternation:
+        for branch in child.children:
+            if len(branch.children) == 1 and _is_unbounded_repetition(
+                branch.children[0]
+            ):
+                return True
+    return False
+
+
+def check_nested_quantifier_redos(reg, errs):
+    num = "129"
+    level = logging.WARNING
+    msg = "Nested quantifier can cause catastrophic backtracking (ReDoS)"
+
+    for rep in find_all_by_type(reg, Other.Repetition):
+        if not _is_unbounded_repetition(rep):
+            continue
+        if len(rep.children) != 1:
+            continue
+        atom = rep.children[0]
+        if atom.type not in _CONSUMING_GROUP:
+            continue
+        if _body_is_ambiguously_repeatable(atom):
+            errs.append((num, level, atom.start or 0, msg))
+
+
 def manual_check_for_empty_string_match(reg, errs, raw_pat):
     # Skip the check in the following conditions:
     # * Rules that use a callback, since they're used for indentation

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -33,6 +33,7 @@ from regexlint.checkers import (
     check_charclass_simplify,
     check_dot_newline_alternation,
     check_multiline_anchors,
+    check_nested_quantifier_redos,
     check_no_bels,
     check_no_consecutive_dots,
     check_no_empty_alternations,
@@ -380,6 +381,56 @@ class CheckersTests(TestCase):
         print(errs)
         self.assertEqual(len(errs), 1)
         self.assertEqual(("107", logging.INFO, 0), errs[0][:3])
+
+    def test_nested_quantifier_redos_plus_plus(self):
+        r = Regex.get_parse_tree(r"(a+)+")
+        errs = []
+        check_nested_quantifier_redos(r, errs)
+        print(errs)
+        self.assertEqual(len(errs), 1)
+        self.assertEqual(("129", logging.WARNING, 0), errs[0][:3])
+
+    def test_nested_quantifier_redos_star_variants(self):
+        for pat in (r"(a+)*", r"(?:a+)*", r"([ab]*)+", r"(a{1,})+", r"(.*)+"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_nested_quantifier_redos(r, errs)
+            print(pat, errs)
+            self.assertEqual(len(errs), 1, pat)
+            self.assertEqual("129", errs[0][0], pat)
+
+    def test_nested_quantifier_redos_alternation_branch(self):
+        r = Regex.get_parse_tree(r"(a+|b)*")
+        errs = []
+        check_nested_quantifier_redos(r, errs)
+        print(errs)
+        self.assertEqual(len(errs), 1)
+        self.assertEqual("129", errs[0][0])
+
+    def test_nested_quantifier_redos_nested_group(self):
+        r = Regex.get_parse_tree(r"(?:(a+))+")
+        errs = []
+        check_nested_quantifier_redos(r, errs)
+        print(errs)
+        self.assertEqual(len(errs), 1)
+
+    def test_nested_quantifier_redos_ok_anchored_body(self):
+        # A mandatory fixed part delimits successive iterations: not ambiguous.
+        for pat in (r"(ab+)+", r"(a+b)+", r"(a|b)+", r"a+", r"(a+)?", r"(a+){2}"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_nested_quantifier_redos(r, errs)
+            print(pat, errs)
+            self.assertEqual(len(errs), 0, pat)
+
+    def test_nested_quantifier_redos_ok_common_string_body(self):
+        # Ubiquitous string-lexer idioms must not be flagged.
+        for pat in (r'(\.|[^"])*', r'([^"\\]|\\.)*'):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_nested_quantifier_redos(r, errs)
+            print(pat, errs)
+            self.assertEqual(len(errs), 0, pat)
 
     def test_unnecessary_i_flag(self):
         r = Regex.get_parse_tree(r"(?i).")


### PR DESCRIPTION
Flag unbounded quantifiers (*, +, open-ended {n,}) applied to a group whose whole body reduces to a single unbounded repetition, e.g. (a+)+, (a+)*, ([ab]*)+, (a{1,})+ and (a+|b)*. These are the classic catastrophic-backtracking shapes where the inner quantifier can split the same input in exponentially many ways.

The check is deliberately conservative to stay false-positive-free on real lexers: bodies with a mandatory fixed part (ab+, a+b), single-char alternations (a|b), bounded outer quantifiers ((a+)?, (a+){2}) and the common string-lexer idioms (\.|[^"])* / ([^"\\]|\\.)* are left alone. This misses multi-atom overlaps like (\w+\s?)*.

Includes unit tests covering the positive, alternation-branch, nested-group and safe/no-flag cases.