### PR TITLE
Add check for single-character alternations (W129)

### DIFF
--- a/regexlint/checkers.py
+++ b/regexlint/checkers.py
@@ -592,6 +592,61 @@ def check_redundant_lookaround(reg, errs):
             )
 
 
+def _foldable_alternation_atom(atom):
+    """Return True when ``atom`` is a single character (or builtin class) that
+    keeps its meaning inside ``[...]``, so a branch consisting solely of it can
+    be folded into a character class."""
+    if atom.type in Other.BuiltinCharclass:
+        return True
+    if atom.type in (Other.Tab, Other.Newline):
+        return True
+    if atom.type in Other.Literal:
+        # Characters that change meaning inside ``[...]`` must not be folded:
+        # ']' closes the class, '-' would form a range (1|-|9 -> [1-9]!), and a
+        # leading '^' negates it. The lexer currently types most of these as
+        # Other.Literals rather than Other.Literal, but guard explicitly so the
+        # safety does not depend on tokenizer internals.
+        return atom.data not in ("]", "-", "^")
+    return False
+
+
+# Metacharacters that need a backslash outside a class but are plain literals
+# inside one, so the escape is redundant in the suggested ``[...]``. ']', '^'
+# and '-' are deliberately excluded: unescaping them would close, negate or
+# turn the class into a range.
+_CLASS_REDUNDANT_ESCAPE = frozenset(".+*?(){}|$")
+
+
+def _render_charclass_member(atom):
+    """Render ``atom`` as it should appear inside a suggested character class,
+    dropping backslashes that become redundant there (e.g. ``\\.`` -> ``.``)."""
+    data = atom.data
+    if len(data) == 2 and data[0] == "\\" and data[1] in _CLASS_REDUNDANT_ESCAPE:
+        return data[1]
+    return data
+
+
+def check_single_char_alternation(reg, errs):
+    num = "129"
+    level = logging.WARNING
+    msg = "Single-character alternation, use a character class %s instead"
+
+    for alt in find_all_by_type(reg, Other.Alternation):
+        atoms = []
+        for branch in alt.children:
+            if len(branch.children) != 1:
+                break
+            atom = branch.children[0]
+            if not _foldable_alternation_atom(atom):
+                break
+            atoms.append(atom)
+        else:
+            # An alternation always has at least two branches; guard anyway.
+            if len(atoms) >= 2:
+                suggestion = "[" + "".join(_render_charclass_member(a) for a in atoms) + "]"
+                errs.append((num, level, alt.start or 0, msg % suggestion))
+
+
 def manual_check_for_empty_string_match(reg, errs, raw_pat):
     # Skip the check in the following conditions:
     # * Rules that use a callback, since they're used for indentation

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -40,6 +40,7 @@ from regexlint.checkers import (
     check_redundant_lookaround,
     check_redundant_repetition,
     check_redundant_whitespace_alternation,
+    check_single_char_alternation,
     check_single_character_classes,
     check_suspicious_anchors,
     check_unescaped_braces,
@@ -380,6 +381,54 @@ class CheckersTests(TestCase):
         print(errs)
         self.assertEqual(len(errs), 1)
         self.assertEqual(("107", logging.INFO, 0), errs[0][:3])
+
+    def test_single_char_alternation_literals(self):
+        r = Regex.get_parse_tree(r"a|b|c")
+        errs = []
+        check_single_char_alternation(r, errs)
+        self.assertEqual(len(errs), 1)
+        self.assertEqual("129", errs[0][0])
+        self.assertIn("[abc]", errs[0][3])
+
+    def test_single_char_alternation_with_builtin_and_escapes(self):
+        r = Regex.get_parse_tree(r"\d|_|\.")
+        errs = []
+        check_single_char_alternation(r, errs)
+        self.assertEqual(len(errs), 1)
+        # The '.' escape is redundant inside a class and is dropped.
+        self.assertIn(r"[\d_.]", errs[0][3])
+
+    def test_single_char_alternation_minimizes_redundant_escapes(self):
+        # Metacharacters that are literal inside a class lose their backslash,
+        # but ']' and '^' must stay escaped so the class is not broken.
+        r = Regex.get_parse_tree(r"\.|\+|\(|\||\]|\^")
+        errs = []
+        check_single_char_alternation(r, errs)
+        self.assertEqual(len(errs), 1)
+        self.assertIn(r"[.+(|\]\^]", errs[0][3])
+
+    def test_single_char_alternation_nested_in_group(self):
+        r = Regex.get_parse_tree(r"(a|b)c")
+        errs = []
+        check_single_char_alternation(r, errs)
+        self.assertEqual(len(errs), 1)
+        self.assertIn("[ab]", errs[0][3])
+
+    def test_single_char_alternation_ignores_multichar(self):
+        for pat in (r"foo|bar", r"a|bc", r"ab|c"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_single_char_alternation(r, errs)
+            self.assertEqual(len(errs), 0, pat)
+
+    def test_single_char_alternation_ignores_non_literal_atoms(self):
+        # '.' changes meaning inside a class; anchors/groups/repeats aren't
+        # single characters, and ']'/'-'/'^' would break or alter the class.
+        for pat in (r"a|.", r"a|b+", r"a|^", r"a|(bc)", r"a|]", r"1|-|9", r"a|^|b"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_single_char_alternation(r, errs)
+            self.assertEqual(len(errs), 0, pat)
 
     def test_unnecessary_i_flag(self):
         r = Regex.get_parse_tree(r"(?i).")


### PR DESCRIPTION
Flag alternations whose every branch is a single foldable character and suggest the equivalent character class, which matches faster and reads more clearly: a|b|c -> [abc], \d|_|\. -> [\d_\.], (a|b)c -> [ab]c.

Foldable atoms are plain literals, single-char escapes (\., \+, \x41, \\, ...), builtin classes (\d \w \s \D \W \S) and \t/\n. Branches that would change meaning or break the class are left alone: multi-char runs (foo|bar), '.', anchors, groups, quantified atoms (a|b+) and a bare ']'.

Includes unit tests for the literal, builtin/escape, nested-in-group and the various no-flag cases.