### PR TITLE
Add check for quantified lookaround assertions (W129)

### DIFF
--- a/regexlint/checkers.py
+++ b/regexlint/checkers.py
@@ -592,6 +592,38 @@ def check_redundant_lookaround(reg, errs):
             )
 
 
+def check_quantified_lookaround(reg, errs):
+    num = "129"
+    level = logging.WARNING
+    # A lookaround matches no characters, so a quantifier on it is always a
+    # mistake, but the consequence differs. When at least one iteration is
+    # required (+, {n}, {n,} with n>=1) the assertion still applies and the
+    # quantifier is merely redundant. When zero iterations are allowed
+    # (*, ?, {0,m}) the assertion can be skipped entirely, which silently
+    # disables it -- a behaviour change rather than a no-op.
+    redundant_msg = "Redundant quantifier on a zero-width lookaround assertion"
+    disabling_msg = (
+        "Quantifier makes a zero-width lookaround assertion optional, "
+        "disabling it"
+    )
+
+    lookarounds = (
+        Other.Open.Lookahead,
+        Other.Open.NegativeLookahead,
+        Other.Open.Lookbehind,
+        Other.Open.NegativeLookbehind,
+    )
+    # Quantified anchors (\b+, ^?) are rejected by the engine before they ever
+    # reach us, so only lookaround groups need checking here.
+    for rep in find_all_by_type(reg, Other.Repetition):
+        if len(rep.children) != 1:
+            continue
+        atom = rep.children[0]
+        if atom.type in lookarounds:
+            msg = disabling_msg if rep.min == 0 else redundant_msg
+            errs.append((num, level, atom.start or 0, msg))
+
+
 def manual_check_for_empty_string_match(reg, errs, raw_pat):
     # Skip the check in the following conditions:
     # * Rules that use a callback, since they're used for indentation

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -37,6 +37,7 @@ from regexlint.checkers import (
     check_no_consecutive_dots,
     check_no_empty_alternations,
     check_prefix_ordering,
+    check_quantified_lookaround,
     check_redundant_lookaround,
     check_redundant_repetition,
     check_redundant_whitespace_alternation,
@@ -380,6 +381,44 @@ class CheckersTests(TestCase):
         print(errs)
         self.assertEqual(len(errs), 1)
         self.assertEqual(("107", logging.INFO, 0), errs[0][:3])
+
+    def test_quantified_lookaround_variants(self):
+        for pat in (r"(?=a)+", r"(?=a)*", r"(?=a)?", r"(?!a)*", r"(?<=a)+", r"(?<!a)?"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_quantified_lookaround(r, errs)
+            self.assertEqual(len(errs), 1, pat)
+            self.assertEqual("129", errs[0][0], pat)
+            self.assertEqual(logging.WARNING, errs[0][1], pat)
+
+    def test_quantified_lookaround_redundant_vs_disabling(self):
+        # +, {n} and {n,} (n>=1) keep the assertion: merely redundant.
+        for pat in (r"(?=a)+", r"(?=a){2}", r"(?=a){1,3}", r"(?<=a){2,}"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_quantified_lookaround(r, errs)
+            self.assertEqual(len(errs), 1, pat)
+            self.assertIn("Redundant", errs[0][3], pat)
+        # *, ? and {0,m} allow zero iterations: they disable the assertion.
+        for pat in (r"(?=a)*", r"(?=a)?", r"(?!a){0,3}"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_quantified_lookaround(r, errs)
+            self.assertEqual(len(errs), 1, pat)
+            self.assertIn("disabling it", errs[0][3], pat)
+
+    def test_quantified_lookaround_in_context(self):
+        r = Regex.get_parse_tree(r"a(?=b)+c")
+        errs = []
+        check_quantified_lookaround(r, errs)
+        self.assertEqual(len(errs), 1)
+
+    def test_quantified_lookaround_ok_unquantified(self):
+        for pat in (r"(?=a)b", r"(?:a)+", r"(a)+", r"a+"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_quantified_lookaround(r, errs)
+            self.assertEqual(len(errs), 0, pat)
 
     def test_unnecessary_i_flag(self):
         r = Regex.get_parse_tree(r"(?i).")


### PR DESCRIPTION
Flag quantifiers applied to a zero-width lookaround, e.g. (?=a)+, (?!a)*, (?<=a)+, (?=a)?. Repeating a zero-width match is a no-op and making an assertion optional simply disables it, so both are almost always mistakes.

Quantified anchors (\b+, ^?) are rejected by the engine at compile time and never reach the linter, so only lookaround groups are checked. Non-quantified lookarounds and quantified real groups ((a)+, (?:a)+) are left alone.

Includes unit tests covering all lookaround kinds and quantifier variants, in-context matches and the no-flag cases.