### PR TITLE
Add check for redundant non-capturing groups (W129)

### DIFF
--- a/regexlint/checkers.py
+++ b/regexlint/checkers.py
@@ -592,6 +592,44 @@ def check_redundant_lookaround(reg, errs):
             )
 
 
+def check_redundant_noncapturing_group(reg, errs):
+    num = "129"
+    level = logging.WARNING
+    msg = "Redundant non-capturing group, the (?:...) can be removed"
+
+    for group in find_all_by_type(reg, Other.Open.NonCapturing):
+        parent = group.parent()
+        quantified = parent is not None and parent.type in Other.Repetition
+        children = group.children
+        single = len(children) == 1
+        child = children[0] if single else None
+
+        if quantified:
+            # A group earns its keep only by binding the quantifier to more than
+            # a single atom. One plain atom means (?:X)q == Xq, but an already
+            # quantified atom ((?:a+)+ would merge into an illegal a++), an
+            # alternation ((?:a|b)+) or a zero-width anchor ((?:^)+ would become
+            # the illegal ^+) must keep the group.
+            redundant = (
+                single
+                and child.type is not Other.Alternation
+                and child.type not in Other.Repetition
+                and child.type not in Other.Anchor
+            )
+        elif single and child.type is Other.Alternation:
+            # A bare alternation needs the group for precedence against any
+            # neighbouring atoms; it is only redundant when it is the whole
+            # pattern, e.g. (?:a|b) but not x(?:a|b)y.
+            redundant = parent is reg and len(reg.children) == 1
+        else:
+            # Unquantified concatenation is associative, so the group boundary is
+            # invisible: (?:ab) == ab, x(?:ab)y == xaby.
+            redundant = True
+
+        if redundant:
+            errs.append((num, level, group.start or 0, msg))
+
+
 def manual_check_for_empty_string_match(reg, errs, raw_pat):
     # Skip the check in the following conditions:
     # * Rules that use a callback, since they're used for indentation

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -38,6 +38,7 @@ from regexlint.checkers import (
     check_no_empty_alternations,
     check_prefix_ordering,
     check_redundant_lookaround,
+    check_redundant_noncapturing_group,
     check_redundant_repetition,
     check_redundant_whitespace_alternation,
     check_single_character_classes,
@@ -380,6 +381,44 @@ class CheckersTests(TestCase):
         print(errs)
         self.assertEqual(len(errs), 1)
         self.assertEqual(("107", logging.INFO, 0), errs[0][:3])
+
+    def test_redundant_noncapturing_group_single_atom(self):
+        for pat in (r"(?:a)", r"(?:a)+", r"(?:\d)*", r"(?:[abc])+", r"(?:(x))", r"(?:a){2}"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_noncapturing_group(r, errs)
+            self.assertEqual(len(errs), 1, pat)
+            self.assertEqual("129", errs[0][0], pat)
+
+    def test_redundant_noncapturing_group_concatenation(self):
+        for pat in (r"(?:ab)", r"x(?:ab)y", r"(?:a+)", r"x(?:a+)y"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_noncapturing_group(r, errs)
+            self.assertEqual(len(errs), 1, pat)
+
+    def test_redundant_noncapturing_group_whole_pattern_alternation(self):
+        for pat in (r"(?:a|b)", r"(?:abc|def)", r"(?:a)|b"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_noncapturing_group(r, errs)
+            self.assertEqual(len(errs), 1, pat)
+
+    def test_redundant_noncapturing_group_needed(self):
+        # The group is load-bearing and must not be flagged.
+        for pat in (r"(?:ab)+", r"(?:a|b)+", r"(?:a+)+", r"x(?:a|b)y", r"(?:a|b)c"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_noncapturing_group(r, errs)
+            self.assertEqual(len(errs), 0, pat)
+
+    def test_redundant_noncapturing_group_quantified_anchor(self):
+        # Removing the group would leave an illegal quantified anchor (^+).
+        for pat in (r"(?:^)+", r"(?:\b)*", r"(?:$)+"):
+            r = Regex.get_parse_tree(pat)
+            errs = []
+            check_redundant_noncapturing_group(r, errs)
+            self.assertEqual(len(errs), 0, pat)
 
     def test_unnecessary_i_flag(self):
         r = Regex.get_parse_tree(r"(?i).")


### PR DESCRIPTION
Flag (?:...) groups that can be removed without changing the match. Unquantified concatenation is associative, so the group boundary is invisible: (?:ab) -> ab, x(?:ab)y -> xaby, (?:a) -> a. A quantified group is redundant only when it wraps a single atom: (?:a)+ -> a+, (?:[abc])+ -> [abc]+.

Load-bearing groups are left alone: a bare alternation keeps the group for precedence unless it is the whole pattern (x(?:a|b)y stays, (?:a|b) -> a|b), quantifiers over multiple atoms ((?:ab)+) or over an alternation ((?:a|b)+), and stacked quantifiers ((?:a+)+, which would otherwise merge into the illegal a++).

Includes unit tests for the single-atom, concatenation, whole-pattern alternation and no-flag cases.