### PR TITLE
Parse scoped inline-flag groups instead of crashing

### DIFF
--- a/regexlint/parser.py
+++ b/regexlint/parser.py
@@ -287,6 +287,11 @@ class BaseRegex(object):
             (r"\|", Other.Alternate),
             (r"\(\?[iLmsux]+\)", Other.Directive),
             (r"\(\?:", Other.Open.NonCapturing),
+            # Scoped inline flags, e.g. (?i:...), (?i-s:...), (?-i:...). This is
+            # a non-capturing group that also sets flags for its body, so it is
+            # NOT interchangeable with a plain (?:...) and gets its own type so
+            # checks (e.g. redundant-group) do not suggest dropping the flags.
+            (r"\(\?[aiLmsux]*(?:-[imsx]+)?:", Other.Open.NonCapturingFlags),
             (r"(\(\?P<)(.*?)(>)", Other.Open.NamedCapturing),
             (r"\(\?=", Other.Open.Lookahead),
             (r"\(\?!", Other.Open.NegativeLookahead),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,6 +35,11 @@ SAMPLE_PATTERNS = [
     r"x{1,}",
     r"x{,5}?",
     r"(?P<first_char>.)(?P=first_char)*",
+    # Scoped inline flags must parse (used to crash) and round-trip.
+    r"(?i:abc)",
+    r"x(?i-s:ab)y",
+    r"(?-i:a)",
+    r"(?ims:a|b)",
 ]
 
 CHARCLASS_PATTERNS = [


### PR DESCRIPTION
(?i:abc) and friends ((?i-s:...), (?-i:...), (?ims:...)) matched no group-opening rule, so the lexer fell through to '(' as a capturing group and then treated the trailing '?' as a quantifier with nothing to bind, raising "IndexError: pop from empty list" in get_parse_tree before any checker could run.

Add a tokenizer rule for scoped inline flags. It is placed after the plain (?:...) rule so ordinary non-capturing groups are unaffected, and it uses a dedicated Other.Open.NonCapturingFlags type rather than Other.Open.NonCapturing: a flag-scoped group is not interchangeable with a bare (?:...) group, so keeping it a distinct type stops checks such as redundant-group from suggesting a removal that would silently drop the flags.

Add the flag-scoped forms to SAMPLE_PATTERNS so the existing reconstruct round-trip test covers both parsing and byte-exact output.